### PR TITLE
PHPUnit の設定ファイルから colors の設定を読み込む

### DIFF
--- a/src/Stagehand/TestRunner/Preparer/PHPUnitPreparer.php
+++ b/src/Stagehand/TestRunner/Preparer/PHPUnitPreparer.php
@@ -96,6 +96,11 @@ class Stagehand_TestRunner_Preparer_PHPUnitPreparer extends Stagehand_TestRunner
             } else {
                 $this->handleBootstrap($phpunitConfiguration['bootstrap']);
             }
+            if (array_key_exists('colors', $phpunitConfiguration)) {
+                if ($phpunitConfiguration['colors'] && @include_once('Console/Color.php')) {
+                    $this->config->colors = true;
+                }
+            }
         }
 
         $browsers = PHPUnit_Util_Configuration::getInstance($this->config->phpunitConfigFile)->getSeleniumBrowserConfiguration();


### PR DESCRIPTION
Stagehand_TestRunner いつも使わせていただいています.
ディレクトリ監視, そして色付きの TestDox がお気に入りです.

ところで, 色付きのオプションを有効にするには -c オプションが必要ですが,
--phpunit-config から読み込んでいるときは, colors の設定を反映できれば, と思いました.

とりあえずこの変更で動いているようですが, ユニットテストまでは用意できませんでした...

また, コードが Stagehand_TestRunner_TestRunnerCLIController と重複してしまってます...

形はどうあれ, 同等の機能についてご検討いただければと思っています.
よろしくお願いします.
