### PR TITLE
PHPUnitCollector で テストスイートの groups プロパティもフィルタ

### DIFF
--- a/src/Stagehand/TestRunner/Collector/PHPUnitCollector.php
+++ b/src/Stagehand/TestRunner/Collector/PHPUnitCollector.php
@@ -163,6 +163,19 @@ class PHPUnitCollector extends Collector
         $numTestsProperty->setAccessible(true);
         $numTestsProperty->setValue($testSuite, -1);
         $numTestsProperty->setAccessible(false);
+
+        $groupsProperty = $testSuiteClass->getProperty('groups');
+        $groupsProperty->setAccessible(true);
+        $groups = $groupsProperty->getValue($testSuite);
+
+        $groups = array_map(function($tests) use ($filteredTests) {
+            return array_filter($tests, function($test) use ($filteredTests) {
+                return in_array($test, $filteredTests, true);
+            });
+        }, $groups);
+
+        $groupsProperty->setValue($testSuite, $groups);
+        $groupsProperty->setAccessible(false);
     }
 }
 


### PR DESCRIPTION
いつも MakeGood と共に使わせていただいています。

phpunit の --phpunit-config の設定ファイルの include でグループを指定すると、特定グループのテストだけを実行することが出来ると思いますが、--test-method と一緒に使用すると意図しないテストメソッドが実行されることがありました。

例えば phpunit.xml が次の通り、

```
<?xml version="1.0" encoding="utf-8" ?>
<phpunit>
    <groups>
      <include>
        <group>xxx</group>
      </include>
    </groups>
</phpunit>
```

テストコード（HogeTest.php）が次の通り、

```
<?php
/**
 * @group xxx
 */
class HogeTest extends PHPUnit_Framework_TestCase
{
    /**
     * @test
     */
    public function hoge1()
    {
        $this->assertTrue(true);
    }

    /**
     * @test
     */
    public function hoge2()
    {
        $this->assertTrue(true);
    }
}
```

次のようにテストを実行すると意図と反して hoge1 と hoge2 の両方のテストが実行されました。

```
testrunner phpunit --phpunit-config=phpunit.xml --test-method=HogeTest::hoge1 tests\HogeTest.php
```

 --test-method でメソッドを指定すると PHPUnitCollector::filterTests() でテストスイートの tests プロパティをフィルタされていましたが、PHPUnit の方で phpunit.xml で include が指定されている場合は groups プロパティの方が参照されているようでしたので、groups プロパティもフィルタするように変更してみました。

ご確認・ご検討をお願いいたします。
