### PR TITLE
junit の failure 要素にトレイトをサポート

### DIFF
--- a/src/Stagehand/TestRunner/Util/FailureTrace.php
+++ b/src/Stagehand/TestRunner/Util/FailureTrace.php
@@ -63,6 +63,14 @@ class FailureTrace
                 return array($trace['file'], $trace['line']);
             }
         }
+        if (method_exists($class, 'getTraits')) {
+            foreach ($class->getTraits() as $trait) {
+                $ret = self::findFileAndLineOfFailureOrError($testClassSuperTypes, $e, $trait);
+                if ($ret) {
+                    return $ret;
+                }
+            }
+        }
         return self::findFileAndLineOfFailureOrError($testClassSuperTypes, $e, $class->getParentClass());
     }
 


### PR DESCRIPTION
Trait でテストメソッド記述してテストケースで use した場合、`--log-junit junit-rt.xml --log-junit-realtime` すると junit 出力に `failure@file` 属性 及び `failure@line` 属性が含まれなくなります。

`Stagehand\TestRunner\Util\FailureTrace::findFileAndLineOfFailureOrError()` で Trait も見るように変更してみました。

[gist](https://gist.github.com/ngyuki/5066179) に置いたものだと php-5.3 で動作しなくなるので、`\ReflectionClass` に `getTraits` メソッドがある場合だけ Trait も見るように変更しています。
