### PR TITLE
php 5.3 で動作するように修正

### DIFF
--- a/src/Stagehand/TestRunner/Collector/Collector.php
+++ b/src/Stagehand/TestRunner/Collector/Collector.php
@@ -111,8 +111,9 @@ abstract class Collector
     {
         $self = $this;
         $fileSystem = new FileSystem();
-        $this->testTargetRepository->walkOnResources(function ($resource, $index, TestTargetRepository $testTargetRepository) use ($self, $fileSystem) {
-            $absoluteTargetPath = $fileSystem->getAbsolutePath($resource, $this->environment->getWorkingDirectoryAtStartup());
+        $environment = $this->environment;
+        $this->testTargetRepository->walkOnResources(function ($resource, $index, TestTargetRepository $testTargetRepository) use ($self, $fileSystem, $environment) {
+            $absoluteTargetPath = $fileSystem->getAbsolutePath($resource, $environment->getWorkingDirectoryAtStartup());
             if (!file_exists($absoluteTargetPath)) {
                 throw new \UnexpectedValueException(sprintf('The directory or file [ %s ] is not found', $absoluteTargetPath));
             }


### PR DESCRIPTION
3.6.0 になってから php 5.3 で動作しなくなっているようです。

``` console
$ php -v
PHP 5.3.19 (cli) (built: Nov 21 2012 21:40:54)
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2012 Zend Technologies
    with Xdebug v2.2.1, Copyright (c) 2002-2012, by Derick Rethans

$ php bin/testrunner phpunit -p test/bootstrap.php test/Stagehand/TestRunner/Runner/PHPUnitRunnerTest.php

Fatal error: Using $this when not in object context in /path/to/stagehand-testrunner\src\Stagehand\TestRunner\Collector\Collector.php on line 115

Call Stack:
    0.0006     361776   1. {main}() /path/to/stagehand-testrunner\bin\testrunner:0
    0.0665    2951568   2. Symfony\Component\Console\Application->run() /path/to/stagehand-testrunner\bin\testrunner:59
    0.0725    3362288   3. Symfony\Component\Console\Application->doRun() /path/to/stagehand-testrunner\vendor\symfony\console\Symfony\Component\Console\Application.php:105
    0.0731    3362288   4. Symfony\Component\Console\Command\Command->run() /path/to/stagehand-testrunner\vendor\symfony\console\Symfony\Component\Console\Application.php:192
    0.0738    3362608   5. Stagehand\TestRunner\CLI\TestRunnerApplication\Command\PluginCommand->execute() /path/to/stagehand-testrunner\vendor\symfony\console\Symfony\Component\Console\Command\Command.php:238
    0.1121    5403176   6. Stagehand\TestRunner\Process\TestRunner->run() /path/to/stagehand-testrunner\src\Stagehand\TestRunner\CLI\TestRunnerApplication\Command\PluginCommand.php:149
    0.1121    5403176   7. Stagehand\TestRunner\Collector\Collector->collect() /path/to/stagehand-testrunner\src\Stagehand\TestRunner\Process\TestRunner.php:106
    0.1122    5403952   8. Stagehand\TestRunner\Core\TestTargetRepository->walkOnResources() /path/to/stagehand-testrunner\src\Stagehand\TestRunner\Collector\Collector.php:132
    0.1122    5404152   9. array_walk() /path/to/stagehand-testrunner\src\Stagehand\TestRunner\Core\TestTargetRepository.php:110
    0.1122    5404216  10. Stagehand\TestRunner\Collector\{closure}() /path/to/stagehand-testrunner\src\Stagehand\TestRunner\Core\TestTargetRepository.php:110
```

`Stagehand\TestRunner\Collector\Collector::collect()` で クロージャーで `$this` を使っていることが原因のようでしたので、`$this->environment` を use するように変更してみました。

ご確認をお願いいたします。
