### PR TITLE
An error "Fatal error: require(): Failed opening required ..." is raised when launching a test with a relative preload script

### DIFF
--- a/bin/testrunner
+++ b/bin/testrunner
@@ -151,6 +151,10 @@ function preloadScript()
         }
 
         if (!is_null($preloadScript)) {
+            if (!isAbsolutePath($preloadScript)) {
+                $preloadScript = getAbsolutePath($preloadScript, workingDirectoryAtStartup());
+            }
+
             $result = include_once $preloadScript;
             if (!$result) {
                 throw new \UnexpectedValueException(sprintf(
@@ -162,6 +166,30 @@ function preloadScript()
     }
 
     return $preloadScript;
+}
+
+/**
+ * @param string $path
+ * @return boolean
+ * @since Method available since Release 4.0.1
+ */
+function isAbsolutePath($path)
+{
+    return preg_match('!^(?:[/\\\]|[a-zA-Z]:[/\\\])!', $path) == 1;
+}
+
+/**
+ * @param string $path
+ * @param string $prefix
+ * @since Method available since Release 4.0.1
+ */
+function getAbsolutePath($path, $prefix)
+{
+    if (isAbsolutePath($path)) {
+        return $path;
+    } else {
+        return $prefix . DIRECTORY_SEPARATOR . $path;
+    }
 }
 
 /*


### PR DESCRIPTION
``` console
$ vendor/bin/testrunner phpunit -p tests/bootstrap.php -R tests

Warning: require(/path/to/project/vendor/phpunit/phpunit-mock-objects/tests/../vendor/autoload.php): failed to open stream: No such file or directory in /path/to/project/vendor/phpunit/phpunit-mock-objects/tests/bootstrap.php on line 4

Call Stack:
    0.0003     271040   1. {main}() /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:0
    0.0018     498584   2. Stagehand\TestRunner\Core\preloadScript() /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:45
    0.0020     501832   3. include_once('/path/to/project/vendor/phpunit/phpunit-mock-objects/tests/bootstrap.php') /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:158


Fatal error: require(): Failed opening required '/path/to/project/vendor/phpunit/phpunit-mock-objects/tests/../vendor/autoload.php' (include_path='/path/to/project/vendor/phake/phake/src:/path/to/project/vendor/phpunit/php-text-template:/path/to/project/vendor/phpunit/phpunit-mock-objects:/path/to/project/vendor/phpunit/php-timer:/path/to/project/vendor/phpunit/php-file-iterator:/path/to/project/vendor/phpunit/php-code-coverage:/path/to/project/vendor/phpunit/phpunit:/path/to/project/vendor/symfony/yaml:.') in /path/to/project/vendor/phpunit/phpunit-mock-objects/tests/bootstrap.php on line 4

Call Stack:
    0.0003     271040   1. {main}() /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:0
    0.0018     498584   2. Stagehand\TestRunner\Core\preloadScript() /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:45
    0.0020     501832   3. include_once('/path/to/project/vendor/phpunit/phpunit-mock-objects/tests/bootstrap.php') /path/to/project/vendor/piece/stagehand-testrunner/bin/testrunner:158
```
