### PR TITLE
Bugfix: Bad quoting

### DIFF
--- a/src/Core/TestTargetRepository.php
+++ b/src/Core/TestTargetRepository.php
@@ -196,7 +196,7 @@ class TestTargetRepository
      */
     public function shouldTreatFileAsTest($file)
     {
-        return (boolean)preg_match('/' . str_replace('/', '\/', $this->getFilePattern()) . '/', basename($file));
+        return (boolean)preg_match('/' . preg_quote($this->getFilePattern(), '/') . '/', basename($file));
     }
 
     /**


### PR DESCRIPTION
Using str_replace() in this form leads to problems on windows when getFilePattern() returns a string containing Backslashes. This is valid on Windows only because it is the DIRECTOR_SEPARATOR on this platform.
Fixed by using the function from PCRE instead of str_replace().