### PR TITLE
[Notification] added OSX Notification Center

### DIFF
--- a/src/Notification/Notifier.php
+++ b/src/Notification/Notifier.php
@@ -59,6 +59,9 @@ class Notifier
     const TITLE_PASSED = 'Test Passed';
     const TITLE_FAILED = 'Test Failed';
     const TITLE_STOPPED = 'Test Stopped';
+    const SOUND_PASSED = 'Hero';
+    const SOUND_FAILED = 'Sosumi';
+    const SOUND_STOPPED = 'Ping';
 
     public static $ICON_PASSED;
     public static $ICON_FAILED;
@@ -111,12 +114,15 @@ class Notifier
         if ($notification->isPassed()) {
             $title = self::TITLE_PASSED;
             $icon = self::$ICON_PASSED;
+            $sound = self::SOUND_PASSED;
         } elseif ($notification->isFailed()) {
             $title = self::TITLE_FAILED;
             $icon = self::$ICON_FAILED;
+            $sound = self::SOUND_FAILED;
         } elseif ($notification->isStopped()) {
             $title = self::TITLE_STOPPED;
             $icon = self::$ICON_STOPPED;
+            $sound = self::SOUND_STOPPED;
         }
 
         if ($this->os->isWin()) {
@@ -129,6 +135,13 @@ class Notifier
                 escapeshellarg(self::TITLE_STOPPED),
                 escapeshellarg($title),
                 escapeshellarg($notification->getMessage())
+            );
+        } elseif ($this->os->isAfterMarvericks() && !$this->hasGrowl('osascript')) {
+            return sprintf(
+                'osascript -e "display notification \"%s\" subtitle \"%s\" sound name \"%s\""',
+                escapeshellarg($notification->getMessage()),
+                escapeshellcmd($title),
+                escapeshellcmd($sound)
             );
         } elseif ($this->os->isDarwin()) {
             return sprintf(
@@ -158,6 +171,16 @@ class Notifier
             $this->legacyProxy->system($command, $exitStatus);
         }
     }
+
+    /**
+     * @return boolean
+     */
+    protected function hasGrowl()
+    {
+        $command = "which growlnotify > /dev/null 2>&1";
+        return $this->legacyProxy->passthru($command) === 0;
+    }
+
 }
 
 /*

--- a/src/Util/OS.php
+++ b/src/Util/OS.php
@@ -78,6 +78,14 @@ class OS
     /**
      * @return boolean
      */
+    public function isAfterMarvericks()
+    {
+        return $this->isDarwin() && php_uname('r') >= 13;
+    }
+
+    /**
+     * @return boolean
+     */
     public function isLinux()
     {
         return strtolower(substr($this->getPHPOS(), 0, strlen('linux'))) == 'linux';


### PR DESCRIPTION
This added OSX native notification feature Notification Center, other than growl.

the commit summary is below,

- change the decision order of notifications 
- added sound parameter for OSX Notification Center

I'm not sure of my selection for the sound.
When it's noisy, I gonna find more suitable one.
 
----

MacのOSXのデフォルト通知機能である、通知センターの対応を追加しました。

- OSXを使用していること
- OSX Marverick以降のバージョンを使用していること
- Growlがインストールされていないこと（whichコマンドでの判定...）

の3点を満たした場合に通知センターを使用するように、
通知機能選択の判定処理を変更しています。

失敗時の音の設定値が若干うるさく感じるかもしれませんが、その場合は他の音に修正いたします。

よろしくお願いいたします。